### PR TITLE
adding go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sans-sroc/integrity
+
+go 1.16


### PR DESCRIPTION
There's no dependencies at this point otherwise there would be more to the file and a go.sum, but generally all projects should have a go.mod. ```go mod init github.com/sans-sroc/integrity``` is how it was generated.