### PR TITLE
ensure when building version pathes we normalize using ToSlash

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/sans-sroc/integrity/pkg/common"
 	"github.com/sans-sroc/integrity/pkg/utils"
@@ -16,7 +17,7 @@ type createCommand struct {
 }
 
 func (w *createCommand) Execute(c *cli.Context) error {
-	dir := c.String("directory")
+	dir := filepath.ToSlash(c.String("directory"))
 	ver := c.String("courseware-version")
 	jsonOut := c.Bool("json")
 	pretty := c.Bool("json-pretty")

--- a/pkg/commands/validate.go
+++ b/pkg/commands/validate.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/sans-sroc/integrity/pkg/common"
 	"github.com/sans-sroc/integrity/pkg/utils"
@@ -13,7 +14,7 @@ type validateCommand struct {
 
 func (w *validateCommand) Execute(c *cli.Context) error {
 	// Validate existing VERSION file(s)
-	dir := c.String("directory")
+	dir := filepath.ToSlash(c.String("directory"))
 	ver := c.String("courseware-version")
 	parts := c.Bool("parts")
 	first := c.Bool("first")

--- a/pkg/utils/validate.go
+++ b/pkg/utils/validate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -15,6 +14,9 @@ import (
 )
 
 func ValidateFiles(directory string, version string, parts bool, first bool, jsonOut bool, jsonPretty bool) bool {
+	// Be sure to normalize \ to /
+	directory = filepath.ToSlash(directory)
+
 	var failed = false
 	verFile := ""
 
@@ -25,11 +27,11 @@ func ValidateFiles(directory string, version string, parts bool, first bool, jso
 	versionFirstFileName := fmt.Sprintf("VERSION-%s-first.txt", version)
 
 	if parts {
-		verFile = path.Join(directory, versionPartFileName)
+		verFile = filepath.Join(directory, versionPartFileName)
 	} else if first {
-		verFile = path.Join(directory, versionFirstFileName)
+		verFile = filepath.Join(directory, versionFirstFileName)
 	} else {
-		verFile = path.Join(directory, versionFileName)
+		verFile = filepath.Join(directory, versionFileName)
 	}
 	_, err := os.Stat(verFile)
 	check(err, "Cannot find VERSION file")


### PR DESCRIPTION
While our cross platform tests were being successful, this ensures the normalization of the directory before use everywhere, this way regardless of windows or linux, the paths in the error messages and in the files are consistent.