### PR TITLE
error if positional arguments are used for directory instead of flag

### DIFF
--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -22,6 +22,10 @@ func (w *createCommand) Execute(c *cli.Context) error {
 	pretty := c.Bool("json-pretty")
 	user := c.String("user")
 
+	if c.Args().Len() > 0 {
+		return fmt.Errorf("Positional arguments are not supported with this command.\n\nDid you mean to use `-d` to change the directory that the command runs against?\n\n")
+	}
+
 	versionFileName := fmt.Sprintf("VERSION-%s.txt", ver)
 	versionPartFileName := fmt.Sprintf("VERSION-%s-part.txt", ver)
 	versionFirstFileName := fmt.Sprintf("VERSION-%s-first.txt", ver)

--- a/pkg/commands/validate.go
+++ b/pkg/commands/validate.go
@@ -20,6 +20,10 @@ func (w *validateCommand) Execute(c *cli.Context) error {
 	json := c.Bool("json")
 	pretty := c.Bool("json-pretty")
 
+	if c.Args().Len() > 0 {
+		return fmt.Errorf("Positional arguments are not supported with this command.\n\nDid you mean to use `-d` to change the directory that the command runs against?\n\n")
+	}
+
 	failed := utils.ValidateFiles(dir, ver, parts, first, json, pretty)
 	if !json {
 		if failed {


### PR DESCRIPTION
In talking with Mark B an error is not thrown if a positional argument is used when trying to pass in a custom directory when the default is `.` for the `-d` flag, this adds a patch to thrown an error if a positional argument is used and suggests that perhaps the user meant to use the `-d` flag.

/cc @philhagen @mark-hallman