### PR TITLE
error if the sans-integrity.yml file does not exist

### DIFF
--- a/pkg/commands/validate.go
+++ b/pkg/commands/validate.go
@@ -25,7 +25,7 @@ func (w *validateCommand) Execute(c *cli.Context) error {
 		return err
 	}
 
-	if _, err := os.Stat(c.String("filename")); err != nil && strings.Contains(err.Error(), "no such file") {
+	if _, err := os.Stat(c.String("filename")); err != nil && strings.Contains(err.Error(), "Error: The sans-integrity.yml checksum file does not exist.") {
 		return err
 	}
 

--- a/pkg/commands/validate.go
+++ b/pkg/commands/validate.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -25,8 +26,8 @@ func (w *validateCommand) Execute(c *cli.Context) error {
 		return err
 	}
 
-	if _, err := os.Stat(c.String("filename")); err != nil && strings.Contains(err.Error(), "Error: The sans-integrity.yml checksum file does not exist.") {
-		return err
+	if _, err := os.Stat(c.String("filename")); err != nil && strings.Contains(err.Error(), "no such file") {
+		return errors.New("Error: The sans-integrity.yml checksum file does not exit.")
 	}
 
 	integrity.SetFilename(c.String("filename"))

--- a/pkg/commands/validate.go
+++ b/pkg/commands/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/sans-sroc/integrity/pkg/common"
 	"github.com/sans-sroc/integrity/pkg/integrity"
@@ -21,6 +22,10 @@ func (w *validateCommand) Execute(c *cli.Context) error {
 
 	integrity, err := integrity.New(c.String("directory"), true)
 	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(c.String("filename")); err != nil && strings.Contains(err.Error(), "no such file") {
 		return err
 	}
 


### PR DESCRIPTION
@philhagen here's the PR that will error the validate command if the `sans-integrity.yml` file does not exist. 

This could be considered a breaking change as it changes the behavior of the validate command, do we want to rev the minor or major version after this is merged? 
